### PR TITLE
makefileをwindowsのclasspath指定に対応

### DIFF
--- a/AIWolfNLGameServer/Makefile
+++ b/AIWolfNLGameServer/Makefile
@@ -2,4 +2,8 @@ clear-log clean-log delete-log:
 	@rm ./log/*.log
 
 run:
+ifeq ($(OS),Windows_NT)
+	java --class-path ./src/;'./lib/*' net/kanolab/aiwolf/server/automatic/AutoGameStarter
+else  # MacOS or Linux
 	java --class-path ./src/:'./lib/*' net/kanolab/aiwolf/server/automatic/AutoGameStarter
+endif


### PR DESCRIPTION
windowsではコロンをセミコロンに変える必要がありました。
変更後もmacで実行できるか確認した方が良いと思います。